### PR TITLE
Disable "help" per default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
-Zimbra News and Events Sidebar
-==========
+# Zimbra News and Events Sidebar
 
-If you find News and Events Sidebar useful and want to support its continued development, you can make donations via:
-- PayPal: info@barrydegraaff.tk
-- Bank transfer: IBAN NL55ABNA0623226413 ; BIC ABNANL2A
+The News and Events Sidebar conveniently displays upcoming events from your Zimbra calendars right on the mail tab.  You can also see the latest items from all of your subscribed news feeds.
 
-_This is the adopted version of the News and Events Sidebar-zimlet_ from University of Guelph.
+To hide this feature for the current session, click on the calendar icon in the header of the New and Events sidebar.
 
-Your appointments, tasks, feeds in a convenient overview on the right side of your mail.
 
-Features:
+## Features
 
   * Display events from all of your checked mail calendars (including shared calendars.)
   * Events are colour coded for each calendar.
@@ -18,3 +14,13 @@ Features:
   * Click on a news item to read the article right in Zimbra mail.
   * Click on the News and Events header to hide the sidebar.
   * Calendars (and news feeds) can be hidden from the sidebar by prefixing their name with a tilde (~) character (e.g. "~Vacation".)
+
+
+## History
+
+This is the adopted version of the [News and Events Sidebar-Zimlet](https://web.archive.org/web/20130208155258/http://www.uoguelph.ca/ccs/gryph-mail/extensions/news-events-sidebar) from University of Guelph.
+
+If you find News and Events Sidebar useful and want to support its continued development, you can make donations via:
+- PayPal: info@barrydegraaff.tk
+- Bank transfer: IBAN NL55ABNA0623226413 ; BIC ABNANL2A
+

--- a/ca_uoguelph_ccs_sidebar/config_template.xml
+++ b/ca_uoguelph_ccs_sidebar/config_template.xml
@@ -1,11 +1,11 @@
 <zimletConfig name="ca_uoguelph_ccs_sidebar" version="1.7">
   <global>
-    <property name="enable_help">true</property>
-    <property name="helpurl">http://www.uoguelph.ca/ccs/gryph-mail/extensions/news-events-sidebar</property>
     <property name="enable_today">true</property>
     <property name="enable_tomorrow">true</property>
     <property name="enable_week">true</property>
     <property name="enable_tasks">true</property>
     <property name="enable_news">true</property>
+    <property name="enable_help">false</property>
+    <property name="helpurl">https://github.com/Zimbra-Community/ca_uoguelph_ccs_sidebar/blob/master/README.md</property>
   </global>
 </zimletConfig>


### PR DESCRIPTION
The old help link is dead. I copied the old text from that page to the README and updated the link to point to that file on GitHub.

Even though there is some kind of "help" now, I disabled it per default since it isn't really helpful (especially for non-native English speakers) and clutters the UI per default. I originally even completely removed this feature but maybe this is helpful to somebody; id that's the case an admin should probably provide their own help text on a local server with a more helpful explanation.